### PR TITLE
add docker registry output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -53,3 +53,7 @@ output "terraform_planners_google_group_id" {
 output "terraformers_google_group_id" {
   value = jsondecode(data.google_storage_bucket_object_content.env_config.content).terraformers_google_group_id
 }
+
+output "docker_registry" {
+  value = jsondecode(data.google_storage_bucket_object_content.env_config.content).docker_registry
+}


### PR DESCRIPTION
can't use `data` field in gcp-env-config because of cdk complications

bump #minor
